### PR TITLE
Add basic FastAPI app

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+app = FastAPI()
+
+# Enable CORS for all origins
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/health")
+async def health() -> dict:
+    """Health check endpoint."""
+    return {"status": "ok"}


### PR DESCRIPTION
## Summary
- implement FastAPI application with CORS enabled
- add `/health` endpoint returning JSON

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68414ace30448329b4c1d8ef51c12aff