### PR TITLE
Add API routes for search and demo resources

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1,0 +1,81 @@
+from fastapi import APIRouter, HTTPException
+from typing import List
+
+from app.schemas import SearchRequest, ResourceOut
+
+router = APIRouter()
+
+# Demo data for example purposes
+_demo_resources: List[ResourceOut] = [
+    ResourceOut(
+        id=1,
+        name="Resource One",
+        url="https://example.com/1",
+        description="First example resource",
+        tags=["example", "demo"],
+    ),
+    ResourceOut(
+        id=2,
+        name="Resource Two",
+        url="https://example.com/2",
+        description="Second example resource",
+        tags=["sample"],
+    ),
+    ResourceOut(
+        id=3,
+        name="Resource Three",
+        url="https://example.com/3",
+        description="Third example resource",
+        tags=["demo"],
+    ),
+    ResourceOut(
+        id=4,
+        name="Resource Four",
+        url="https://example.com/4",
+        description="Fourth example resource",
+        tags=["demo", "test"],
+    ),
+    ResourceOut(
+        id=5,
+        name="Resource Five",
+        url="https://example.com/5",
+        description="Fifth example resource",
+        tags=["example"],
+    ),
+]
+
+
+@router.post("/search", response_model=List[ResourceOut])
+async def search_resources(payload: SearchRequest) -> List[ResourceOut]:
+    """Simple search over demo data."""
+    results = _demo_resources
+    if payload.keyword:
+        keyword = payload.keyword.lower()
+        results = [
+            r
+            for r in results
+            if keyword in r.name.lower()
+            or (r.description and keyword in r.description.lower())
+        ]
+    if payload.filters:
+        results = [
+            r
+            for r in results
+            if r.tags and any(tag in payload.filters for tag in r.tags)
+        ]
+    return results
+
+
+@router.get("/details/{resource_id}", response_model=ResourceOut)
+async def get_resource(resource_id: int) -> ResourceOut:
+    """Return a resource by id from the demo dataset."""
+    for res in _demo_resources:
+        if res.id == resource_id:
+            return res
+    raise HTTPException(status_code=404, detail="Resource not found")
+
+
+@router.get("/demo", response_model=List[ResourceOut])
+async def demo_resources() -> List[ResourceOut]:
+    """Return hardcoded demo resources."""
+    return _demo_resources

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,8 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.api.routes import router
+
 app = FastAPI()
 
 # Enable CORS for all origins
@@ -11,6 +13,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Register API routes
+app.include_router(router)
 
 
 @app.get("/health")


### PR DESCRIPTION
## Summary
- implement FastAPI router with demo data and routes
- register router in the main app

## Testing
- `python -m py_compile backend/app/api/routes.py backend/app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68415a2b64588329aab1e84e7bf474de