### PR TITLE
Implement ResourceCard UI

### DIFF
--- a/frontend/src/components/DetailModal.tsx
+++ b/frontend/src/components/DetailModal.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalCloseButton,
+  ModalBody,
+  ModalFooter,
+  Button,
+  Text,
+  Stack,
+  Tag,
+  Wrap,
+  WrapItem,
+} from '@chakra-ui/react';
+import { Resource } from './ResourceCard';
+
+interface DetailModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  resource: Resource;
+}
+
+/**
+ * Modal displaying detailed information about a resource.
+ */
+const DetailModal: React.FC<DetailModalProps> = ({ isOpen, onClose, resource }) => (
+  <Modal isOpen={isOpen} onClose={onClose} size="lg">
+    <ModalOverlay />
+    <ModalContent>
+      <ModalHeader>{resource.name}</ModalHeader>
+      <ModalCloseButton />
+      <ModalBody>
+        {resource.description && <Text mb={4}>{resource.description}</Text>}
+        {resource.tags && resource.tags.length > 0 && (
+          <Wrap mb={4}>
+            {resource.tags.map((tag) => (
+              <WrapItem key={tag}>
+                <Tag>{tag}</Tag>
+              </WrapItem>
+            ))}
+          </Wrap>
+        )}
+        {resource.partners && resource.partners.length > 0 && (
+          <Stack spacing={1} fontSize="sm" color="gray.600">
+            <Text fontWeight="bold">Partners Involved</Text>
+            <Text>{resource.partners.join(', ')}</Text>
+          </Stack>
+        )}
+      </ModalBody>
+      <ModalFooter>
+        <Button onClick={onClose}>Close</Button>
+      </ModalFooter>
+    </ModalContent>
+  </Modal>
+);
+
+export default DetailModal;

--- a/frontend/src/components/ResourceCard.tsx
+++ b/frontend/src/components/ResourceCard.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import {
+  Box,
+  Heading,
+  Text,
+  Stack,
+  Tag,
+  Wrap,
+  WrapItem,
+  Button,
+  useDisclosure,
+} from '@chakra-ui/react';
+import DetailModal from './DetailModal';
+
+export interface Resource {
+  id: number;
+  name: string;
+  description?: string;
+  tags?: string[];
+  partners?: string[];
+}
+
+interface ResourceCardProps {
+  resource: Resource;
+}
+
+/**
+ * Display a summary card for a resource with a details modal.
+ */
+const ResourceCard: React.FC<ResourceCardProps> = ({ resource }) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  return (
+    <Box borderWidth="1px" borderRadius="md" p={4}>
+      <Stack spacing={3}>
+        <Heading size="md">{resource.name}</Heading>
+        {resource.description && (
+          <Text noOfLines={2}>{resource.description}</Text>
+        )}
+        {resource.tags && resource.tags.length > 0 && (
+          <Wrap>
+            {resource.tags.map((tag) => (
+              <WrapItem key={tag}>
+                <Tag>{tag}</Tag>
+              </WrapItem>
+            ))}
+          </Wrap>
+        )}
+        {resource.partners && resource.partners.length > 0 && (
+          <Text fontSize="sm" color="gray.600">
+            Partners: {resource.partners.join(', ')}
+          </Text>
+        )}
+        <Button alignSelf="start" onClick={onOpen} size="sm" colorScheme="blue">
+          Details
+        </Button>
+      </Stack>
+      <DetailModal isOpen={isOpen} onClose={onClose} resource={resource} />
+    </Box>
+  );
+};
+
+export default ResourceCard;


### PR DESCRIPTION
## Summary
- add a Chakra UI `ResourceCard` with name, description, tags and partners
- include a details modal via new `DetailModal` component

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684166b2ae648329af3133756da8d743