### PR TITLE
Add Home page with search filters

### DIFF
--- a/frontend/src/components/ResourceList.tsx
+++ b/frontend/src/components/ResourceList.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { SimpleGrid, Text } from '@chakra-ui/react';
+import ResourceCard from './ResourceCard';
+import type { Resource } from '../utils/api';
+
+interface ResourceListProps {
+  resources: Resource[];
+}
+
+const ResourceList: React.FC<ResourceListProps> = ({ resources }) => {
+  if (!resources || resources.length === 0) {
+    return <Text>No resources found.</Text>;
+  }
+
+  return (
+    <SimpleGrid spacing={4} columns={{ base: 1, md: 2, lg: 3 }}>
+      {resources.map((res) => (
+        <ResourceCard key={res.id} resource={res} />
+      ))}
+    </SimpleGrid>
+  );
+};
+
+export default ResourceList;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,0 +1,48 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Spinner, Text, VStack } from '@chakra-ui/react';
+import Filters from '../components/Filters';
+import ResourceList from '../components/ResourceList';
+import { searchResources, type SearchFilters, type Resource } from '../utils/api';
+
+/**
+ * Home page showing Filters and search results. Results are fetched
+ * from the backend whenever filter values change.
+ */
+const Home: React.FC = () => {
+  const [filters, setFilters] = useState<SearchFilters>({});
+  const [results, setResults] = useState<Resource[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchResults = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await searchResources(filters);
+      setResults(data);
+    } catch (err) {
+      setError('Failed to load resources');
+    } finally {
+      setLoading(false);
+    }
+  }, [filters]);
+
+  useEffect(() => {
+    fetchResults();
+  }, [fetchResults]);
+
+  return (
+    <VStack spacing={4} align="stretch" p={4}>
+      <Filters onFilterChange={setFilters} />
+      {loading && <Spinner alignSelf="center" />}
+      {error && (
+        <Text color="red.500" textAlign="center">
+          {error}
+        </Text>
+      )}
+      {!loading && !error && <ResourceList resources={results} />}
+    </VStack>
+  );
+};
+
+export default Home;


### PR DESCRIPTION
## Summary
- create `ResourceList` component to display resources
- implement `Home` page using `Filters` and new `ResourceList`
- fetch resources whenever filters change and show loading/error states

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684169a92104832993b3dd802790d9bf