### PR TITLE
Implement Docker setup and demo search page

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir fastapi uvicorn[standard] && \
+    pip install --no-cache-dir -r requirements.txt
+COPY app ./app
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: query
+      POSTGRES_PASSWORD: query
+      POSTGRES_DB: query
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+  chroma:
+    image: ghcr.io/chroma-core/chroma:latest
+    volumes:
+      - chroma_data:/chroma/.chroma
+    ports:
+      - "8001:8000"
+
+  backend:
+    build: ./backend
+    environment:
+      DATABASE_URL: postgresql://query:query@db:5432/query
+      CHROMA_URL: http://chroma:8000
+    depends_on:
+      - db
+      - chroma
+    ports:
+      - "8000:8000"
+
+  frontend:
+    build: ./frontend
+    environment:
+      REACT_APP_API_URL: http://backend:8000
+    depends_on:
+      - backend
+    ports:
+      - "3000:3000"
+
+volumes:
+  db_data:
+  chroma_data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,15 @@
+# Build stage
+FROM node:18 AS build
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM node:18-slim
+WORKDIR /app
+RUN npm install -g serve
+COPY --from=build /app/build ./build
+EXPOSE 3000
+CMD ["serve", "-s", "build"]

--- a/frontend/src/pages/Demo.tsx
+++ b/frontend/src/pages/Demo.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { Button, Spinner, Text, VStack } from '@chakra-ui/react';
+import ResourceList from '../components/ResourceList';
+import { searchResources, type Resource, type SearchFilters } from '../utils/api';
+
+// List of predefined demo searches. Each label corresponds to filters passed
+// to the search API when the button is clicked.
+const demos: { label: string; filters: SearchFilters }[] = [
+  { label: 'wraparound for teens', filters: { keyword: 'wraparound', filters: ['teens'] } },
+  { label: 'residential services in Alameda', filters: { keyword: 'residential', filters: ['alameda'] } },
+  { label: 'drop in centers', filters: { keyword: 'drop in center', filters: ['center'] } },
+  { label: 'bilingual therapy', filters: { keyword: 'bilingual therapy', filters: ['bilingual'] } },
+  { label: 'family support groups', filters: { keyword: 'family support', filters: ['family'] } },
+];
+
+/**
+ * Demo page that exposes a set of predefined searches. Clicking a button will
+ * execute the corresponding search and display the results below.
+ */
+const Demo: React.FC = () => {
+  const [results, setResults] = useState<Resource[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const runDemo = async (filters: SearchFilters) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await searchResources(filters);
+      setResults(data);
+    } catch (_) {
+      setError('Failed to load resources');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <VStack spacing={4} align="stretch" p={4}>
+      {demos.map((demo) => (
+        <Button key={demo.label} onClick={() => runDemo(demo.filters)}>
+          {demo.label}
+        </Button>
+      ))}
+      {loading && <Spinner alignSelf="center" />}
+      {error && (
+        <Text color="red.500" textAlign="center">
+          {error}
+        </Text>
+      )}
+      {!loading && !error && results.length > 0 && (
+        <ResourceList resources={results} />
+      )}
+    </VStack>
+  );
+};
+
+export default Demo;


### PR DESCRIPTION
## Summary
- implement Demo page with 5 predefined searches
- add docker-compose setup with backend, frontend, db and chroma services
- build backend with FastAPI in Python 3.11
- build frontend React app and serve static bundle

## Testing
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416abd77d48329a20962a35c3ee231