### PR TITLE
Improve demo search features and build setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Query Demo App
+
+This repository contains a small demo application composed of a FastAPI backend and a React frontend.
+
+## Development
+
+- `docker-compose up --build` will start PostgreSQL, ChromaDB, the API and the React app.
+- The API is available at `http://localhost:8000` and the React app at `http://localhost:3000`.
+
+The backend exposes a `/search` endpoint that supports the following fields:
+
+- `keyword` – free text search over name, description and eligibility
+- `age` – integer to filter resources within the age range
+- `county` – one of the counties configured in the sample data
+- `insurance` – insurance type
+- `system` – list of systems
+- `tags` – list of tags
+
+## Data
+
+For demonstration purposes the API serves a handful of in-memory resources. The Excel loader and Chroma integration utilities are provided but not wired to the demo data.

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -3,11 +3,19 @@ from pydantic import BaseModel
 
 
 class ResourceBase(BaseModel):
-    """Shared attributes for resources excluding the database id."""
+    """Shared attributes for resources."""
 
     name: str
     url: Optional[str] = None
     description: Optional[str] = None
+    eligibility: Optional[str] = None
+    service_type: Optional[str] = None
+    system: Optional[str] = None
+    min_age: Optional[int] = None
+    max_age: Optional[int] = None
+    counties: Optional[List[str]] = None
+    insurance_types: Optional[List[str]] = None
+    partners: Optional[List[str]] = None
     tags: Optional[List[str]] = None
 
 
@@ -21,4 +29,8 @@ class SearchRequest(BaseModel):
     """Payload accepted by the search API."""
 
     keyword: Optional[str] = None
-    filters: Optional[List[str]] = None
+    age: Optional[int] = None
+    county: Optional[str] = None
+    insurance: Optional[str] = None
+    system: Optional[List[str]] = None
+    tags: Optional[List[str]] = None

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "query-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
+  },
+  "dependencies": {
+    "@chakra-ui/react": "^2.8.1",
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "axios": "^1.6.7",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1",
+    "typescript": "^5.2.2"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Query App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,29 +1,11 @@
-import React, { useState } from 'react';
-import { ChakraProvider, Box, Container } from '@chakra-ui/react';
-import Filters from './components/Filters';
-import ResourceList from './components/ResourceList';
+import React from 'react';
+import { ChakraProvider } from '@chakra-ui/react';
+import Home from './pages/Home';
 
-/**
- * Main App layout using Chakra UI.
- * Renders Filters component and below it the ResourceList.
- * useState is used to track filter values and search results.
- */
-const App: React.FC = () => {
-  // Track the currently selected filters
-  const [filters, setFilters] = useState<Record<string, string | string[]>>({});
-  // Hold the resources returned from the API or filter logic
-  const [results, setResults] = useState<any[]>([]);
-
-  return (
-    <ChakraProvider>
-      <Container maxW="container.xl" py={4}>
-        <Box mb={4}>
-          <Filters filters={filters} setFilters={setFilters} onSearch={setResults} />
-        </Box>
-        <ResourceList resources={results} />
-      </Container>
-    </ChakraProvider>
-  );
-};
+const App: React.FC = () => (
+  <ChakraProvider>
+    <Home />
+  </ChakraProvider>
+);
 
 export default App;

--- a/frontend/src/components/DetailModal.tsx
+++ b/frontend/src/components/DetailModal.tsx
@@ -14,7 +14,7 @@ import {
   Wrap,
   WrapItem,
 } from '@chakra-ui/react';
-import { Resource } from './ResourceCard';
+import type { Resource } from '../utils/api';
 
 interface DetailModalProps {
   isOpen: boolean;
@@ -33,6 +33,11 @@ const DetailModal: React.FC<DetailModalProps> = ({ isOpen, onClose, resource }) 
       <ModalCloseButton />
       <ModalBody>
         {resource.description && <Text mb={4}>{resource.description}</Text>}
+        {resource.eligibility && (
+          <Text mb={2} fontStyle="italic">
+            Eligibility: {resource.eligibility}
+          </Text>
+        )}
         {resource.tags && resource.tags.length > 0 && (
           <Wrap mb={4}>
             {resource.tags.map((tag) => (
@@ -47,6 +52,16 @@ const DetailModal: React.FC<DetailModalProps> = ({ isOpen, onClose, resource }) 
             <Text fontWeight="bold">Partners Involved</Text>
             <Text>{resource.partners.join(', ')}</Text>
           </Stack>
+        )}
+        {resource.counties && (
+          <Text fontSize="sm" color="gray.600">
+            Counties: {resource.counties.join(', ')}
+          </Text>
+        )}
+        {resource.insurance_types && (
+          <Text fontSize="sm" color="gray.600">
+            Insurance: {resource.insurance_types.join(', ')}
+          </Text>
         )}
       </ModalBody>
       <ModalFooter>

--- a/frontend/src/components/Filters.tsx
+++ b/frontend/src/components/Filters.tsx
@@ -15,16 +15,12 @@ import {
   VStack,
 } from '@chakra-ui/react';
 
-interface FiltersState {
-  age: number;
-  county: string;
-  insurance: string;
-  system: string[];
-  keyword: string;
-}
+import type { SearchFilters } from '../utils/api';
+
+type FiltersState = SearchFilters;
 
 interface FiltersProps {
-  onFilterChange: (filters: FiltersState) => void;
+  onFilterChange: (filters: SearchFilters) => void;
 }
 
 const counties = ['County A', 'County B', 'County C'];

--- a/frontend/src/components/ResourceCard.tsx
+++ b/frontend/src/components/ResourceCard.tsx
@@ -11,14 +11,7 @@ import {
   useDisclosure,
 } from '@chakra-ui/react';
 import DetailModal from './DetailModal';
-
-export interface Resource {
-  id: number;
-  name: string;
-  description?: string;
-  tags?: string[];
-  partners?: string[];
-}
+import type { Resource } from '../utils/api';
 
 interface ResourceCardProps {
   resource: Resource;
@@ -49,6 +42,14 @@ const ResourceCard: React.FC<ResourceCardProps> = ({ resource }) => {
         {resource.partners && resource.partners.length > 0 && (
           <Text fontSize="sm" color="gray.600">
             Partners: {resource.partners.join(', ')}
+          </Text>
+        )}
+        {resource.system && (
+          <Text fontSize="sm" color="gray.600">System: {resource.system}</Text>
+        )}
+        {resource.counties && (
+          <Text fontSize="sm" color="gray.600">
+            Counties: {resource.counties.join(', ')}
           </Text>
         )}
         <Button alignSelf="start" onClick={onOpen} size="sm" colorScheme="blue">

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const rootElement = document.getElementById('root');
+if (rootElement) {
+  const root = createRoot(rootElement);
+  root.render(<App />);
+}

--- a/frontend/src/pages/Demo.tsx
+++ b/frontend/src/pages/Demo.tsx
@@ -6,11 +6,11 @@ import { searchResources, type Resource, type SearchFilters } from '../utils/api
 // List of predefined demo searches. Each label corresponds to filters passed
 // to the search API when the button is clicked.
 const demos: { label: string; filters: SearchFilters }[] = [
-  { label: 'wraparound for teens', filters: { keyword: 'wraparound', filters: ['teens'] } },
-  { label: 'residential services in Alameda', filters: { keyword: 'residential', filters: ['alameda'] } },
-  { label: 'drop in centers', filters: { keyword: 'drop in center', filters: ['center'] } },
-  { label: 'bilingual therapy', filters: { keyword: 'bilingual therapy', filters: ['bilingual'] } },
-  { label: 'family support groups', filters: { keyword: 'family support', filters: ['family'] } },
+  { label: 'wraparound for teens', filters: { keyword: 'wraparound', tags: ['teens'] } },
+  { label: 'residential services in Alameda', filters: { keyword: 'residential', county: 'Alameda' } },
+  { label: 'drop in centers', filters: { keyword: 'drop in center' } },
+  { label: 'bilingual therapy', filters: { keyword: 'bilingual therapy' } },
+  { label: 'family support groups', filters: { keyword: 'family support' } },
 ];
 
 /**

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -10,7 +10,11 @@ const apiClient = axios.create({
 
 export interface SearchFilters {
   keyword?: string;
-  filters?: string[];
+  age?: number;
+  county?: string;
+  insurance?: string;
+  system?: string[];
+  tags?: string[];
 }
 
 export interface Resource {
@@ -18,6 +22,14 @@ export interface Resource {
   name: string;
   url?: string;
   description?: string;
+  eligibility?: string;
+  service_type?: string;
+  system?: string;
+  min_age?: number | null;
+  max_age?: number | null;
+  counties?: string[];
+  insurance_types?: string[];
+  partners?: string[];
   tags?: string[];
 }
 


### PR DESCRIPTION
## Summary
- provide basic project README
- expand backend schemas to support filters
- update demo data and search endpoint to use filters
- align frontend models with API
- wire Home page through new App and index
- add placeholder package.json and HTML entry for React

## Testing
- `python -m py_compile backend/app/*.py backend/app/api/*.py backend/app/utils/*.py`
- `npx tsc --noEmit` *(fails: no tsconfig)*

------
https://chatgpt.com/codex/tasks/task_e_68416cb8a2608329b5df3a4ab03f5cdb